### PR TITLE
BLDK-734:RDK License header changes-for Notice header update

### DIFF
--- a/NOTICE
+++ b/NOTICE
@@ -1,5 +1,11 @@
-Copyright 2020 RDK Management
-Licensed under the Apache License, Version 2.0 
+This component contains software that is Copyright (c) 2020 RDK Management.
+The component is licensed to you under the Apache License, Version 2.0 (the "License").
+You may not use the component except in compliance with the License.
+
+The component may include material which is licensed under other licenses / copyrights as
+listed below. Your use of this material within the component is also subject to the terms and
+conditions of these licenses. The LICENSE file contains the text of all the licenses which apply
+within this component.
 
 Copyright 2016-2017 TATA ELXSI
 Copyright 2016-2017 Metrological


### PR DESCRIPTION
BLDK-734:RDK License header changes-for Notice header update
Reason for change: RDK License header changes-for Notice header update
Test Procedure: Jenkin build should pass after License header changes for RDK for listed repos
Risks: None